### PR TITLE
Test routing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/*,bang/conftest.py,bang/app.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requests = "^2.25.1"
 requests-wsgi-adapter = "^0.4.1"
 pre-commit = "^2.9.3"
 toml = "^0.10.2"
+pytest-cov = "^2.10.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0a5"]

--- a/tests/test_bang.py
+++ b/tests/test_bang.py
@@ -46,3 +46,25 @@ def test_default_404_response(client):
 
     assert response.status_code == 404
     assert response.text == "Not found."
+
+
+def test_class_based_handler_get(app, client):
+    @app.route("/book")
+    class BookResource:
+        def get(self, req, resp):
+            resp.text = "get"
+
+    assert client.get("http://testserver/book").text == "get"
+
+
+def test_class_based_handler_post(app, client):
+    @app.route("/person")
+    class PersonResource:
+        def post(self, req, resp):
+            resp.text = "post"
+
+    assert client.post("http://testserver/person").text == "post"
+
+    # and undefined method raises
+    with pytest.raises(AttributeError):
+        client.get("http://testserver/person").text

--- a/tests/test_bang.py
+++ b/tests/test_bang.py
@@ -11,7 +11,7 @@ def test_basic_route_adding(app):
         resp.text = "YOLO"
 
 
-def test_no_duplicate_routes(app):
+def test_duplicate_routes_throws_exception(app):
     @app.route("/home")
     def home(req, resp):
         resp.text = "YOLO"
@@ -39,6 +39,7 @@ def test_parameterized_route(app, client):
         resp.text = f"Hello, {name}"
 
     assert client.get("http://testserver/hello/Nathan").text == "Hello, Nathan"
+    assert client.get("http://testserver/hello/Beast").text == "Hello, Beast"
 
 
 def test_default_404_response(client):
@@ -65,6 +66,13 @@ def test_class_based_handler_post(app, client):
 
     assert client.post("http://testserver/person").text == "post"
 
+
+def test_class_based_handler_not_allowed(app, client):
+    @app.route("/wookie")
+    class PersonResource:
+        def post(self, req, resp):
+            resp.text = "post"
+
     # and undefined method raises
     with pytest.raises(AttributeError):
-        client.get("http://testserver/person").text
+        client.get("http://testserver/wookie").text


### PR DESCRIPTION
This adds tests to the bang framework's route decorator, which is at present the only way to create routes.