### PR TITLE
Add an add_route method to the API

### DIFF
--- a/bang/api.py
+++ b/bang/api.py
@@ -22,6 +22,11 @@ class BangAPI:
         response = self.handle_request(request)
         return response(environ, start_response)
 
+    def add_route(self, path: str, handler: Handler):
+        if path in self.routes:
+            raise AttributeError(f"Route for path {path} already exists.")
+        self.routes[path] = handler
+
     def route(self, path: str):
         if path in self.routes:
             raise AttributeError(f"Route for path {path} already exists.")

--- a/bang/api.py
+++ b/bang/api.py
@@ -28,11 +28,8 @@ class BangAPI:
         self.routes[path] = handler
 
     def route(self, path: str):
-        if path in self.routes:
-            raise AttributeError(f"Route for path {path} already exists.")
-
         def wrapper(handler: Handler):
-            self.routes[path] = handler
+            self.add_route(path, handler)
             return handler
 
         return wrapper

--- a/tests/test_bang.py
+++ b/tests/test_bang.py
@@ -76,3 +76,11 @@ def test_class_based_handler_not_allowed(app, client):
     # and undefined method raises
     with pytest.raises(AttributeError):
         client.get("http://testserver/wookie").text
+
+
+def test_add_route(app, client):
+    def do_handle(req, resp):
+        resp.text = "Route add method"
+
+    app.add_route("/chewbaca", do_handle)
+    assert client.get("http://testserver/chewbaca").text == "Route add method"


### PR DESCRIPTION
We started with a decorator for this, but now moved the base logic into the add_route method which can be used by the developer in addition to following the decorator approach.