### PR TITLE
Add automation scripts to poetry

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = tests/*,bang/conftest.py,bang/app.py
+omit = tests/*,bang/conftest.py,bang/app.py,scripts.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "app"
+name = "bang"
 version = "0.1.0"
 description = "The framework that began history."
 authors = ["Nathan Slaughter <nslaughter@users.noreply.github.com>"]
@@ -19,6 +19,11 @@ requests-wsgi-adapter = "^0.4.1"
 pre-commit = "^2.9.3"
 toml = "^0.10.2"
 pytest-cov = "^2.10.1"
+
+[tool.poetry.scripts]
+pre_commit = "scripts:pre_commit"
+test = "scripts:test"
+coverage = "scripts:coverage"
 
 [build-system]
 requires = ["poetry-core>=1.0.0a5"]

--- a/scripts.py
+++ b/scripts.py
@@ -1,0 +1,15 @@
+# This is a temporary workaround till Poetry supports scripts, see
+# https://github.com/sdispater/poetry/issues/241.
+from subprocess import check_call
+
+
+def pre_commit() -> None:
+    check_call(["pre-commit", "run", "--all-files"])
+
+
+def test() -> None:
+    check_call(["pytest", "tests/"])
+
+
+def coverage() -> None:
+    check_call(["pytest", "--cov", "."])


### PR DESCRIPTION
Adds several scripts to `poetry run`, so we can run a few commands like `yarn run ...` and such. This adds the scripts in a single file (scripts.py), makes them accessible as commands in `poetry run` by adding to the `pyproject.toml`, and adds the scripts file to coverage exclusion.