### PR TITLE
Add exception if method isn't provided on path

### DIFF
--- a/bang/api.py
+++ b/bang/api.py
@@ -4,7 +4,7 @@ This is the core for Bang web apps.
 """
 import inspect
 import os
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict
 
 from jinja2 import Environment, FileSystemLoader
 from parse import parse
@@ -13,15 +13,14 @@ from whitenoise import WhiteNoise
 
 from .middleware import Middleware
 
-
 Handler = Callable[[Request], Response]
 
-    
+
 class BangAPI:
     """BangAPI is the WSGI compatible class for handling web requests.
 
     """
-    routes: Dict[str, Handler] = {}
+    routes: Dict[str, Dict[str, Any]] = {}
     templates_env: Environment = Environment(
         loader=FileSystemLoader(os.path.abspath("bang/templates")))
     exception_handler = None
@@ -52,9 +51,14 @@ class BangAPI:
             raise AttributeError(f"Route for path {path} already exists.")
 
         if allowed_methods is None:
-            allowed_methods = ['get', 'post', 'put', 'patch', 'delete', 'options']
+            allowed_methods = [
+                'get', 'post', 'put', 'patch', 'delete', 'options'
+            ]
 
-        self.routes[path] = {"handler": handler, "allowed_methods": allowed_methods}
+        self.routes[path] = {
+            "handler": handler,
+            "allowed_methods": allowed_methods
+        }
 
     def route(self, path: str, allowed_methods=None):
         def wrapper(handler: Handler):
@@ -87,7 +91,8 @@ class BangAPI:
                 if inspect.isclass(handler):
                     handler = getattr(handler(), request.method.lower(), None)
                     if handler is None:
-                        raise AttributeError("Method not allowed", request.method)
+                        raise AttributeError("Method not allowed",
+                                             request.method)
                 elif request.method.lower() not in allowed_methods:
                     raise AttributeError("Method not allowed", request.method)
                 handler(request, response, **kwargs)

--- a/bang/api.py
+++ b/bang/api.py
@@ -4,7 +4,7 @@ This is the core for Bang web apps.
 """
 import inspect
 import os
-from typing import Callable, Dict
+from typing import Callable, Dict, List
 
 from jinja2 import Environment, FileSystemLoader
 from parse import parse
@@ -16,7 +16,7 @@ from .middleware import Middleware
 
 Handler = Callable[[Request], Response]
 
-
+    
 class BangAPI:
     """BangAPI is the WSGI compatible class for handling web requests.
 
@@ -47,14 +47,18 @@ class BangAPI:
         response = self.handle_request(request)
         return response(environ, start_response)
 
-    def add_route(self, path: str, handler: Handler):
+    def add_route(self, path: str, handler: Handler, allowed_methods=None):
         if path in self.routes:
             raise AttributeError(f"Route for path {path} already exists.")
-        self.routes[path] = handler
 
-    def route(self, path: str):
+        if allowed_methods is None:
+            allowed_methods = ['get', 'post', 'put', 'patch', 'delete', 'options']
+
+        self.routes[path] = {"handler": handler, "allowed_methods": allowed_methods}
+
+    def route(self, path: str, allowed_methods=None):
         def wrapper(handler: Handler):
-            self.add_route(path, handler)
+            self.add_route(path, handler, allowed_methods)
             return handler
 
         return wrapper
@@ -64,24 +68,28 @@ class BangAPI:
         response.text = "Not found."
 
     def find_handler(self, request_path):
-        for path, handler in self.routes.items():
+        for path, handler_data in self.routes.items():
             parse_result = parse(path, request_path)
             if parse_result is not None:
-                return handler, parse_result.named
+                return handler_data, parse_result.named
 
         return None, None
 
     def handle_request(self, request):
         response = Response()
 
-        handler, kwargs = self.find_handler(request_path=request.path)
+        handler_data, kwargs = self.find_handler(request_path=request.path)
 
         try:
-            if handler is not None:
+            if handler_data is not None:
+                handler = handler_data["handler"]
+                allowed_methods = handler_data["allowed_methods"]
                 if inspect.isclass(handler):
                     handler = getattr(handler(), request.method.lower(), None)
                     if handler is None:
                         raise AttributeError("Method not allowed", request.method)
+                elif request.method.lower() not in allowed_methods:
+                    raise AttributeError("Method not allowed", request.method)
                 handler(request, response, **kwargs)
             else:
                 self.default_response(response)

--- a/tests/test_bang.py
+++ b/tests/test_bang.py
@@ -3,18 +3,19 @@
 Test the App framework.
 """
 import pytest
-# from pytest.mock import create_autospec
 
-from .conftest import FixtureAPI
 from bang.middleware import Middleware
 
+from .conftest import FixtureAPI
+
+# from pytest.mock import create_autospec
 
 FILE_DIR = "css"
 FILE_NAME = "main.css"
 FILE_CONTENTS = "body {background-color: red}"
 
-
 # helpers
+
 
 def _create_static(static_dir):
     asset = static_dir.mkdir(FILE_DIR).join(FILE_NAME)
@@ -24,6 +25,7 @@ def _create_static(static_dir):
 
 
 # tests
+
 
 def test_basic_route_adding(app):
     @app.route("/basic")
@@ -182,7 +184,7 @@ def test_middleware_methods_are_called(app, client):
     assert process_request_called is True
     assert process_response_called is True
 
-    
+
 def test_disallow_unhandled_methods_for_function_handlers(app, client):
     @app.route("/home3", allowed_methods=["post"])
     def home(req, resp):

--- a/tests/test_bang.py
+++ b/tests/test_bang.py
@@ -181,3 +181,14 @@ def test_middleware_methods_are_called(app, client):
 
     assert process_request_called is True
     assert process_response_called is True
+
+    
+def test_disallow_unhandled_methods_for_function_handlers(app, client):
+    @app.route("/home3", allowed_methods=["post"])
+    def home(req, resp):
+        resp.text = "hello"
+
+    with pytest.raises(AttributeError):
+        client.get("http://testserver/home3")
+
+    assert client.post("http://testserver/home3").text == "hello"


### PR DESCRIPTION
### What?
Addresses #26. When we get a request for an HTTP method (verb - e.g. put) on a path where it issn't defined our function based handler doesn't do anything. But the class based handler would throw an exception which we caught and provided the 404.

### Why?
Recognizing this situation and returning 404 is the correct behavior. We simply didn't have that implemented and thus left it up to framework users to implement this behavior manually even though it's a predictable situation which they should handle consistently.

### How?
We added an `allowed_methods` argument to our `add_route` method which now puts the `allowed_methods` field along with the handler on each `path`.

### Testing?
* We check directly that we get the expected response with an allowed method and raise an error otherwise.
* The def for the new test is `def test_disallow_unhandled_methods_for_function_handlers(app, client)`.