### PR TITLE
Add Response media type detection

### DIFF
--- a/bang/api.py
+++ b/bang/api.py
@@ -12,6 +12,7 @@ from webob import Request, Response
 from whitenoise import WhiteNoise
 
 from .middleware import Middleware
+from .response import Response
 
 Handler = Callable[[Request], Response]
 

--- a/bang/api.py
+++ b/bang/api.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict
 
 from jinja2 import Environment, FileSystemLoader
 from parse import parse
-from webob import Request, Response
+from webob import Request
 from whitenoise import WhiteNoise
 
 from .middleware import Middleware

--- a/bang/app.py
+++ b/bang/app.py
@@ -41,15 +41,6 @@ class BooksResource:
         resp.text = "Endpoint to delete a book"
 
 
-@app.route("/template")
-def template_handler(req, resp):
-    resp.body = app.template("index.html",
-                             context={
-                                 "name": "Bang",
-                                 "title": "Best Framework"
-                             }).encode()
-
-
 def custom_exception_handler(request, response, exception_cls):
     response.text = str(exception_cls)
 
@@ -72,14 +63,21 @@ class SimpleCustomMiddleware(Middleware):
 
 app.add_middleware(SimpleCustomMiddleware)
 
-@app.route("/template5")
-def template_handler(req, resp):
-    resp.html = app.template("index.html", context={"name": "bang", "title": "Bangin' Framework"})
 
-@app.route("/json5")
+@app.route("/template")
+def template_handler(req, resp):
+    resp.html = app.template("index.html",
+                             context={
+                                 "name": "bang",
+                                 "title": "Bangin' Framework"
+                             })
+
+
+@app.route("/json")
 def json_handler(req, resp):
     resp.json = {"name": "data", "type": "JSON"}
 
-@app.route("/text5")
+
+@app.route("/text")
 def text_handler(req, resp):
     resp.text = "This is a simple text"

--- a/bang/app.py
+++ b/bang/app.py
@@ -71,3 +71,15 @@ class SimpleCustomMiddleware(Middleware):
 
 
 app.add_middleware(SimpleCustomMiddleware)
+
+@app.route("/template5")
+def template_handler(req, resp):
+    resp.html = app.template("index.html", context={"name": "bang", "title": "Bangin' Framework"})
+
+@app.route("/json5")
+def json_handler(req, resp):
+    resp.json = {"name": "data", "type": "JSON"}
+
+@app.route("/text5")
+def text_handler(req, resp):
+    resp.text = "This is a simple text"

--- a/bang/response.py
+++ b/bang/response.py
@@ -4,24 +4,26 @@ The bang Response type should be natural to anyone familiar with HTTP.
 """
 import json
 from dataclasses import dataclass
+from typing import Optional
 
 from webob import Response as WOResponse
 
+
 @dataclass
 class Response:
-    status_code: int = None
-    reason_phrase: str = None
-    json: str = None
-    html: str = None
-    text: str = None
-    content_type: str = None
+    status_code: Optional[int] = None
+    reason_phrase: Optional[str] = None
+    json: Optional[str] = None
+    html: Optional[str] = None
+    text: Optional[str] = None
+    content_type: Optional[str] = None
     body: bytes = b''
 
     def __call__(self, environ, start_response):
         self.set_body_and_content_type()
-        response = WOResponse(
-            body=self.body, content_type=self.content_type, status=self.status_code
-        )
+        response = WOResponse(body=self.body,
+                              content_type=self.content_type,
+                              status=self.status_code)
         return response(environ, start_response)
 
     def set_body_and_content_type(self):

--- a/bang/response.py
+++ b/bang/response.py
@@ -1,0 +1,38 @@
+"""Response is one of two HTTP message types as described in RFC 7231.
+
+The bang Response type should be natural to anyone familiar with HTTP.
+"""
+import json
+from dataclasses import dataclass
+
+from webob import Response as WOResponse
+
+@dataclass
+class Response:
+    status_code: int = None
+    reason_phrase: str = None
+    json: str = None
+    html: str = None
+    text: str = None
+    content_type: str = None
+    body: bytes = b''
+
+    def __call__(self, environ, start_response):
+        self.set_body_and_content_type()
+        response = WOResponse(
+            body=self.body, content_type=self.content_type, status=self.status_code
+        )
+        return response(environ, start_response)
+
+    def set_body_and_content_type(self):
+        if self.json is not None:
+            self.body = json.dumps(self.json).encode('UTF-8')
+            self.content_type = "application/json"
+
+        if self.html is not None:
+            self.body = self.html.encode()
+            self.content_type = "text/html"
+
+        if self.text is not None:
+            self.body = self.text
+            self.content_type = "text/plain"

--- a/tests/test_bang.py
+++ b/tests/test_bang.py
@@ -195,6 +195,7 @@ def test_disallow_unhandled_methods_for_function_handlers(app, client):
 
     assert client.post("http://testserver/home3").text == "hello"
 
+
 def test_json_response_helper(app, client):
     @app.route("/json")
     def json_handler(req, resp):
@@ -210,7 +211,11 @@ def test_json_response_helper(app, client):
 def test_html_response_helper(app, client):
     @app.route("/html2")
     def html_handler(req, resp):
-        resp.html = app.template("index.html", context={"title": "Best Title", "name": "Best Name"})
+        resp.html = app.template("index.html",
+                                 context={
+                                     "title": "Best Title",
+                                     "name": "Best Name"
+                                 })
 
     response = client.get("http://testserver/html2")
 

--- a/tests/test_bang.py
+++ b/tests/test_bang.py
@@ -194,3 +194,51 @@ def test_disallow_unhandled_methods_for_function_handlers(app, client):
         client.get("http://testserver/home3")
 
     assert client.post("http://testserver/home3").text == "hello"
+
+def test_json_response_helper(app, client):
+    @app.route("/json")
+    def json_handler(req, resp):
+        resp.json = {"name": "bang"}
+
+    response = client.get("http://testserver/json")
+    json_body = response.json()
+
+    assert response.headers["Content-Type"] == "application/json"
+    assert json_body["name"] == "bang"
+
+
+def test_html_response_helper(app, client):
+    @app.route("/html2")
+    def html_handler(req, resp):
+        resp.html = app.template("index.html", context={"title": "Best Title", "name": "Best Name"})
+
+    response = client.get("http://testserver/html2")
+
+    assert "text/html" in response.headers["Content-Type"]
+    assert "Best Title" in response.text
+    assert "Best Name" in response.text
+
+
+def test_text_response_helper(app, client):
+    response_text = "Just Plain Text"
+
+    @app.route("/text")
+    def text_handler(req, resp):
+        resp.text = response_text
+
+    response = client.get("http://testserver/text")
+
+    assert "text/plain" in response.headers["Content-Type"]
+    assert response.text == response_text
+
+
+def test_manually_setting_body(app, client):
+    @app.route("/body")
+    def text_handler(req, resp):
+        resp.body = b"Byte Body"
+        resp.content_type = "text/plain"
+
+    response = client.get("http://testserver/body")
+
+    assert "text/plain" in response.headers["Content-Type"]
+    assert response.text == "Byte Body"


### PR DESCRIPTION
### What?
We're making media_types exclusive with a method on the custom response which allows as to set them appropriately. 
Addresses #29

### Why?
Proper rendering of the content depends upon the media_content.

### How?
1. Created a custom `Response` type to wrap the one we've been using from pylonsproject's `webob`.
2. Added a method called `set_body_and_content_type` to encode body to match content-type.

### Testing?
We test that the response helper performs as expected for json, text, and html in `test_text_response_helper`, `test_html_response_helper`, and `test_json_response_helper`. We also test manually setting the body with `test_manually_setting_body`.